### PR TITLE
Bumping taoensso/encore to upstream

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,2 @@
+github: ptaoussanis
+custom: "https://www.taoensso.com/clojure/backers"

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ As an example:
 ```clojure
 `(tr [["Hi %1, please enter your **login details** below:"]] [user-name])`
 
-;; Will compiled the inner resource to an optimized function like this:
+;; Will compile the inner resource to an optimized function like this:
 
 (fn [user-name] [:span "Hi " user-name ", please enter your " [:strong "login details"] " below:"])
 ```

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@
 
 > See [here](https://taoensso.com/clojure/backers) if you're interested in helping support my open-source work, thanks! - Peter Taoussanis
 
-# Tempura
-
-### Pure Clojure/Script i18n translations library
+# Tempura: a pure Clojure/Script i18n translations library
 
 ## Objectives
 
@@ -30,7 +28,8 @@
 Add the necessary dependency to your project:
 
 ```clojure
-[com.taoensso/tempura "1.2.1"]
+Leiningen: [com.taoensso/tempura "1.2.1"] ; or
+deps.edn:   com.taoensso/tempura {:mvn/version "1.2.1"}
 ```
 
 Setup your namespace imports:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@
  * All-Clojure **(edn) dictionary format** for ease of use, easy compile-**and-runtime** manipulation, etc.
  * Focus only on common-case **translation** and no other aspects of i18n/L10n.
 
+## Tutorial
+
+See [here][tutorial] for a detailed tutorial by [Dr. Wolfram Schroers][@field-theory] (thanks Wolfram!).
+
 ## Quickstart
 
 Add the necessary dependency to your project:
@@ -220,3 +224,5 @@ Copyright &copy; 2016-2020 [Peter Taoussanis].
 <!--- Unique links -->
 [gettext]: https://en.wikipedia.org/wiki/Gettext
 [Reagent]: https://github.com/reagent-project/reagent
+[tutorial]: https://gist.github.com/field-theory/b7c05953e32645d880eae382171a85d7
+[@field-theory]: https://github.com/field-theory

--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@
 [com.taoensso/tempura "1.2.1"]
 ```
 
-> Please consider helping to [support my continued open-source Clojure/Script work]? 
-> 
-> Even small contributions can add up + make a big difference to help sustain my time writing, maintaining, and supporting Tempura and other Clojure/Script libraries. **Thank you!**
->
-> \- Peter Taoussanis
+> See [here](https://taoensso.com/clojure/backers) if you're interested in helping support my open-source work, thanks! - Peter Taoussanis
 
 # Tempura
 
@@ -205,7 +201,7 @@ Otherwise, you can reach me at [Taoensso.com]. Happy hacking!
 ## License
 
 Distributed under the [EPL v1.0] \(same as Clojure).  
-Copyright &copy; 2020 [Peter Taoussanis].
+Copyright &copy; 2016-2020 [Peter Taoussanis].
 
 <!--- Standard links -->
 [Taoensso.com]: https://www.taoensso.com
@@ -213,7 +209,6 @@ Copyright &copy; 2020 [Peter Taoussanis].
 [@ptaoussanis]: https://www.taoensso.com
 [More by @ptaoussanis]: https://www.taoensso.com
 [Break Version]: https://github.com/ptaoussanis/encore/blob/master/BREAK-VERSIONING.md
-[support my continued open-source Clojure/Script work]: http://taoensso.com/clojure/backers
 
 <!--- Standard links (repo specific) -->
 [CHANGELOG]: https://github.com/ptaoussanis/tempura/releases

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Otherwise, you can reach me at [Taoensso.com]. Happy hacking!
 ## License
 
 Distributed under the [EPL v1.0] \(same as Clojure).  
-Copyright &copy; 2016 [Peter Taoussanis].
+Copyright &copy; 2020 [Peter Taoussanis].
 
 <!--- Standard links -->
 [Taoensso.com]: https://www.taoensso.com

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                 *assert*             true}
 
   :dependencies
-  [[com.taoensso/encore "2.118.0"]]
+  [[com.taoensso/encore "3.9.2"]]
 
   :plugins
   [[lein-pprint    "1.2.0"]

--- a/project.clj
+++ b/project.clj
@@ -11,8 +11,7 @@
                 *assert*             true}
 
   :dependencies
-  [[org.clojure/clojure "1.7.0"]
-   [com.taoensso/encore "2.118.0"]]
+  [[com.taoensso/encore "2.118.0"]]
 
   :plugins
   [[lein-pprint    "1.2.0"]
@@ -23,12 +22,14 @@
   :profiles
   {;; :default [:base :system :user :provided :dev]
    :server-jvm {:jvm-opts ^:replace ["-server"]}
+   :provided {:dependencies [[org.clojure/clojure       "1.7.0"]
+                             [org.clojure/clojurescript "1.10.597"]]}
    :1.8      {:dependencies [[org.clojure/clojure "1.8.0"]]}
    :1.9      {:dependencies [[org.clojure/clojure "1.9.0"]]}
    :1.10     {:dependencies [[org.clojure/clojure "1.10.1"]]}
    :test     {:dependencies [[org.clojure/test.check "0.10.0"]]}
-   :provided {:dependencies [[org.clojure/clojurescript "1.10.597"]]}
-   :dev [:1.9 :test :server-jvm]}
+   :depr     {:jvm-opts ["-Dtaoensso.elide-deprecated=true"]}
+   :dev      [:1.9 :test :server-jvm :depr]}
 
   :cljsbuild
   {:test-commands
@@ -52,4 +53,5 @@
    "start-dev"  ["with-profile" "+dev" "repl" ":headless"]}
 
   :repositories
-  {"sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"})
+  {"sonatype-oss-public"
+   "https://oss.sonatype.org/content/groups/public/"})

--- a/project.clj
+++ b/project.clj
@@ -12,12 +12,12 @@
 
   :dependencies
   [[org.clojure/clojure "1.7.0"]
-   [com.taoensso/encore "2.94.0"]]
+   [com.taoensso/encore "2.118.0"]]
 
   :plugins
   [[lein-pprint    "1.2.0"]
    [lein-ancient   "0.6.15"]
-   [lein-codox     "0.10.3"]
+   [lein-codox     "0.10.7"]
    [lein-cljsbuild "1.1.7"]]
 
   :profiles
@@ -25,8 +25,9 @@
    :server-jvm {:jvm-opts ^:replace ["-server"]}
    :1.8      {:dependencies [[org.clojure/clojure "1.8.0"]]}
    :1.9      {:dependencies [[org.clojure/clojure "1.9.0"]]}
-   :test     {:dependencies [[org.clojure/test.check "0.9.0"]]}
-   :provided {:dependencies [[org.clojure/clojurescript "1.10.145"]]}
+   :1.10     {:dependencies [[org.clojure/clojure "1.10.1"]]}
+   :test     {:dependencies [[org.clojure/test.check "0.10.0"]]}
+   :provided {:dependencies [[org.clojure/clojurescript "1.10.597"]]}
    :dev [:1.9 :test :server-jvm]}
 
   :cljsbuild

--- a/src/taoensso/tempura.cljc
+++ b/src/taoensso/tempura.cljc
@@ -27,8 +27,9 @@
 
 ;;;;
 
-(def ^:private get-default-resource-compiler
-  "Good general-purpose resource compiler.
+(def get-default-resource-compiler
+  "Implementation detail.
+  Good general-purpose resource compiler.
   Supports output of text, and Hiccup forms with simple Markdown styles."
   (enc/memoize_
     (fn [{:keys [escape-html?]}]

--- a/src/taoensso/tempura/impl.cljc
+++ b/src/taoensso/tempura/impl.cljc
@@ -37,9 +37,8 @@
         [(enc/str-replace s uuid-esc "%")]
         (let [arg-idxs (mapv str->?arg-idx ?arg-seq)
               splits   (str/split s re-clojure-arg)
-              splits   (mapv (fn [s] (enc/str-replace s uuid-esc "%")) splits)
-              _        (have (fn [arg-idxs-count splits-count]
-                               (= arg-idxs-count (- splits-count 1))))]
+              splits   (mapv (fn [s] (enc/str-replace s uuid-esc "%")) splits)]
+
           (enc/vinterleave-all splits arg-idxs))))))
 
 (comment
@@ -220,7 +219,7 @@
       (if-not (string? in)
         (conj acc in)
         (let [parts (str->split-args in)
-              parts (mapv (fn [p] (if (string? p) p (symbol (str "%" (inc p)))))
+              parts (mapv (fn [p] (if (string? p) p (symbol (str "%" (inc (long p))))))
                       parts)]
           (into acc parts))))
     v))

--- a/src/taoensso/tempura/impl.cljc
+++ b/src/taoensso/tempura/impl.cljc
@@ -259,8 +259,10 @@
         s (replace-matches s   #"(\*)([^\*\r\n]+)\1" :em)
         s (replace-matches s    #"(_)([^_\r\n]+)\1"  :i)
 
-        ;; This common enough to be worthwhile?
-        s (replace-matches s   #"(~~)([^~\r\n]+)\1"  :s) ; Strikeout
+        ;;; Specials (for arbitrary inline styling, etc.)
+        s (replace-matches s   #"(~~)([^~\r\n]+)\1"  :mark)
+        s (replace-matches s  #"(~1~)([^~\r\n]+)\1"  :span.tspecl1)
+        s (replace-matches s  #"(~2~)([^~\r\n]+)\1"  :span.tspecl2)
 
         s (enc/str-replace s uuid-esc*      "*")
         s (enc/str-replace s uuid-esc_      "_")
@@ -275,7 +277,7 @@
             splits (str/split s (re-pattern (str/join "|" ordered-match-ks)))]
         (enc/vinterleave-all splits ordered-match-vs)))))
 
-(comment (str->split-styles "_hello_ **there** this is a _test_ `*yo`*"))
+(comment (str->split-styles "_hello_ **there** this is a _test_ `*yo`* ~1~hello~1~"))
 
 (defn vec->vtag
   "[\"foo\"] -> [:span \"foo\"] as a convenience."


### PR DESCRIPTION
## Changelog:
- Bumping `taoensso/encore` to `3.9.2`

## Why this bump?

If a project refers to both dependencies `taoensso/carmine` and `taoensso/tempura` in their latest releases (`v3.1.0` and `v1.2.1` respectively) there will be a dependency override issue.

`taoensso/carmine` requires the `taoensso/encore` dependency on the version `3.9.2`
`taoensso/tempura` requires the `taoensso/encore` dependency on the version `2.118.0`

When both are used on the same project, there will be a code incompatibility issue due to different dependency versions being required.