### PR TITLE
Bump encore and use non-deprecated encore fn

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
    :url  "https://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies
-  [[com.taoensso/encore "3.31.0"]]
+  [[com.taoensso/encore "3.112.0"]]
 
   :test-paths ["test" #_"src"]
 

--- a/src/taoensso/tempura.cljc
+++ b/src/taoensso/tempura.cljc
@@ -42,7 +42,7 @@
                 (enc/sb-append sb (str x1))
                 (enc/str-builder  (str x1))))))]
 
-    (if (and (== (count out) 2) (enc/kw-identical? (nth out 0) :span))
+    (if (and (== (count out) 2) (enc/identical-kw? (nth out 0) :span))
       (nth out 1)
       (do  out))))
 


### PR DESCRIPTION
I have a project the uses `nippy` and `tempura`. In bumping `nippy` to the latest I now get the following failure (not sure why it isn't just a warning) due to `tempura`'s usage of a deprecated `encore` function. I guess [`nippy` accepts `encore` as low as `3.58.0`](https://github.com/taoensso/nippy/blob/af3957f4dbe09c4cc158d5c95e83937672286e1b/src/taoensso/nippy.clj#L28)  and it looks like `3.66.0` is the version that deprecates `kw-identical?`. 
Regardless, I figured I'd bump it here so others don't need to do such git spelunking and version gymnastics.
```
------ ERROR -------------------------------------------------------------------
 File: jar:file:/home/runner/.m2/repository/com/taoensso/tempura/1.5.3/tempura-1.5.3.jar!/taoensso/tempura.cljc:44:33
--------------------------------------------------------------------------------
  41 |                 (enc/sb-append sb (str x1))
  42 |                 (enc/str-builder  (str x1))))))]
  43 | 
  44 |     (if (and (== (count out) 2) (enc/kw-identical? (nth out 0) :span))
---------------------------------------^----------------------------------------
null
taoensso.encore/kw-identical? is deprecated
{:warning :fn-deprecated, :line 44, :column 33, :msg "taoensso.encore/kw-identical? is deprecated", :shadow.build.compiler/warning-as-error true}
ExceptionInfo: taoensso.encore/kw-identical? is deprecated
	shadow.build.compiler/warning-collector (compiler.clj:631)
```